### PR TITLE
Copy all language files to english language folder on build

### DIFF
--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -103,7 +103,7 @@
   <ItemGroup>
     <ContentWithTargetPath Include="About\**" CopyToOutputDirectory="PreserveNewest" TargetPath="..\About\%(Filename)%(Extension)" />
     <ContentWithTargetPath Include="Defs\**" CopyToOutputDirectory="PreserveNewest" TargetPath="..\Defs\%(RecursiveDir)%(Filename)%(Extension)" />
-    <ContentWithTargetPath Include="Languages\**" CopyToOutputDirectory="PreserveNewest" TargetPath="..\Languages\%(Filename)%(Extension)" />
+    <ContentWithTargetPath Include="Languages\**" CopyToOutputDirectory="PreserveNewest" TargetPath="..\Languages\English\Keyed\%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />


### PR DESCRIPTION
This isn't a perfect fix, ideally the whole language folder should be copied. This is an immediate fix to get it into people's hands