### PR TITLE
Add more variety to bought good/bad colonists

### DIFF
--- a/Source/RimConnection/Managers/PawnCreationManager.cs
+++ b/Source/RimConnection/Managers/PawnCreationManager.cs
@@ -19,12 +19,24 @@ namespace RimConnection
         });
 
         private static List<Trait> goodTraits = new List<Trait>(new Trait[] {
+            new Trait(TraitDefOf.Beauty, 1),
+            new Trait(TraitDefOf.NaturalMood, 1),
+            new Trait(TraitDefOf.Nerves, 1),
+            new Trait(TraitDefOf.Industriousness, 1),
+            new Trait(TraitDefOf.SpeedOffset, 1),
             new Trait(TraitDefOf.Beauty, 2),
             new Trait(TraitDefOf.NaturalMood, 2),
             new Trait(TraitDefOf.Nerves, 2),
             new Trait(TraitDefOf.Industriousness, 2),
-            new Trait(TraitDefOf.Cannibal),
             new Trait(TraitDefOf.SpeedOffset, 2),
+            new Trait(TraitDefOf.Cannibal),
+            new Trait(TraitDefOf.GreatMemory),
+            new Trait(TraitDefOf.Tough),
+            new Trait(DefDatabase<TraitDef>.GetNamed("Immunity"), 1),
+            new Trait(DefDatabase<TraitDef>.GetNamed("FastLearner")),
+            new Trait(TraitDefOf.Kind),
+            new Trait(DefDatabase<TraitDef>.GetNamed("Nimble")),
+            new Trait(DefDatabase<TraitDef>.GetNamed("QuickSleeper")),
         });
 
         public static List<Thing> generateDefaultColonists(int amount, string name = null)
@@ -105,11 +117,32 @@ namespace RimConnection
                 var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
                 newPawn.SetFaction(Faction.OfPlayer);
 
-                var randomTraits = goodTraits.InRandomOrder().Take(3);
-                newPawn.story.traits.allTraits.Clear();
+                // Create a dictionary to store available traits for each trait type
+                Dictionary<TraitDef, List<Trait>> availableTraits = new Dictionary<TraitDef, List<Trait>>();
+                foreach (Trait trait in goodTraits)
+                {
+                    if (!availableTraits.ContainsKey(trait.def))
+                    {
+                        availableTraits[trait.def] = new List<Trait>();
+                    }
+                    availableTraits[trait.def].Add(trait);
+                }
 
-                // Make their traits great
-                foreach (Trait trait in randomTraits)
+                List<Trait> selectedTraits = new List<Trait>();
+
+                // Randomly select 3 different trait types
+                while (selectedTraits.Count < 3 && availableTraits.Count > 0)
+                {
+                    TraitDef randomTraitDef = availableTraits.Keys.RandomElement();
+                    List<Trait> traitsForType = availableTraits[randomTraitDef];
+                    Trait selectedTrait = traitsForType.RandomElement();
+                    selectedTraits.Add(selectedTrait);
+                    availableTraits.Remove(randomTraitDef);
+                }
+
+                newPawn.story.traits.allTraits.Clear();
+                // Add the selected traits to the pawn
+                foreach (Trait trait in selectedTraits)
                 {
                     newPawn.story.traits.GainTrait(trait);
                 }

--- a/Source/RimConnection/Managers/PawnCreationManager.cs
+++ b/Source/RimConnection/Managers/PawnCreationManager.cs
@@ -10,12 +10,25 @@ namespace RimConnection
     {
         private static List<Trait> badTraits = new List<Trait>(new Trait[] {
             new Trait(TraitDefOf.Beauty, -2),
-            new Trait(TraitDefOf.Pyromaniac),
             new Trait(TraitDefOf.NaturalMood, -2),
             new Trait(TraitDefOf.Nerves, -2),
-            new Trait(TraitDefOf.DrugDesire, 1),
             new Trait(TraitDefOf.Industriousness, -2),
+            new Trait(TraitDefOf.Beauty, -1),
+            new Trait(TraitDefOf.NaturalMood, -1),
+            new Trait(TraitDefOf.Nerves, -1),
+            new Trait(TraitDefOf.Industriousness, -1),
             new Trait(TraitDefOf.SpeedOffset, -1),
+            new Trait(TraitDefOf.DrugDesire, 1),
+            new Trait(TraitDefOf.DrugDesire, 2),
+            new Trait(TraitDefOf.Pyromaniac),
+            new Trait(TraitDefOf.Wimp),
+            new Trait(TraitDefOf.Greedy),
+            new Trait(TraitDefOf.Jealous),
+            new Trait(TraitDefOf.Abrasive),
+            new Trait(TraitDefOf.AnnoyingVoice),
+            new Trait(TraitDefOf.CreepyBreathing),
+            new Trait(DefDatabase<TraitDef>.GetNamed("Immunity"), -1),
+            new Trait(DefDatabase<TraitDef>.GetNamed("SlowLearner")),
         });
 
         private static List<Trait> goodTraits = new List<Trait>(new Trait[] {
@@ -81,10 +94,32 @@ namespace RimConnection
                 var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
                 newPawn.SetFaction(Faction.OfPlayer);
 
-                // fuck up their traits
-                var randomTraits = badTraits.InRandomOrder().Take(3);
+                // Create a dictionary to store available traits for each trait type
+                Dictionary<TraitDef, List<Trait>> availableTraits = new Dictionary<TraitDef, List<Trait>>();
+                foreach (Trait trait in badTraits)
+                {
+                    if (!availableTraits.ContainsKey(trait.def))
+                    {
+                        availableTraits[trait.def] = new List<Trait>();
+                    }
+                    availableTraits[trait.def].Add(trait);
+                }
+
+                List<Trait> selectedTraits = new List<Trait>();
+
+                // Randomly select 3 different trait types
+                while (selectedTraits.Count < 3 && availableTraits.Count > 0)
+                {
+                    TraitDef randomTraitDef = availableTraits.Keys.RandomElement();
+                    List<Trait> traitsForType = availableTraits[randomTraitDef];
+                    Trait selectedTrait = traitsForType.RandomElement();
+                    selectedTraits.Add(selectedTrait);
+                    availableTraits.Remove(randomTraitDef);
+                }
+
                 newPawn.story.traits.allTraits.Clear();
-                foreach (Trait trait in randomTraits)
+                // Add the selected traits to the pawn
+                foreach (Trait trait in selectedTraits)
                 {
                     newPawn.story.traits.GainTrait(trait);
                 }
@@ -185,10 +220,32 @@ namespace RimConnection
                     newPawn.Name = new NameTriple("Worst", "Myseenee", "Ever");
                 }
 
-                var randomTraits = badTraits;
-                newPawn.story.traits.allTraits.Clear();
+                // Create a dictionary to store available traits for each trait type
+                Dictionary<TraitDef, List<Trait>> availableTraits = new Dictionary<TraitDef, List<Trait>>();
+                foreach (Trait trait in badTraits)
+                {
+                    if (!availableTraits.ContainsKey(trait.def))
+                    {
+                        availableTraits[trait.def] = new List<Trait>();
+                    }
+                    availableTraits[trait.def].Add(trait);
+                }
 
-                foreach (Trait trait in randomTraits)
+                List<Trait> selectedTraits = new List<Trait>();
+
+                // Randomly select 5 different trait types
+                while (selectedTraits.Count < 5 && availableTraits.Count > 0)
+                {
+                    TraitDef randomTraitDef = availableTraits.Keys.RandomElement();
+                    List<Trait> traitsForType = availableTraits[randomTraitDef];
+                    Trait selectedTrait = traitsForType.RandomElement();
+                    selectedTraits.Add(selectedTrait);
+                    availableTraits.Remove(randomTraitDef);
+                }
+
+                newPawn.story.traits.allTraits.Clear();
+                // Add the selected traits to the pawn
+                foreach (Trait trait in selectedTraits)
                 {
                     newPawn.story.traits.GainTrait(trait);
                 }

--- a/Source/RimConnection/Managers/PawnCreationManager.cs
+++ b/Source/RimConnection/Managers/PawnCreationManager.cs
@@ -8,6 +8,9 @@ namespace RimConnection
 {
     class PawnCreationManager
     {
+        private static Dictionary<TraitDef, List<Trait>> badTraitDict;
+        private static Dictionary<TraitDef, List<Trait>> goodTraitDict;
+
         private static List<Trait> badTraits = new List<Trait>(new Trait[] {
             new Trait(TraitDefOf.Beauty, -2),
             new Trait(TraitDefOf.NaturalMood, -2),
@@ -53,6 +56,48 @@ namespace RimConnection
             new Trait(DefDatabase<TraitDef>.GetNamed("NightOwl")),
         });
 
+        private static Dictionary<TraitDef, List<Trait>> InitializeTraitDictionary(List<Trait> traits)
+        {
+            Dictionary<TraitDef, List<Trait>> traitDict = new Dictionary<TraitDef, List<Trait>>();
+            foreach (Trait trait in traits)
+            {
+                if (!traitDict.ContainsKey(trait.def))
+                {
+                    traitDict[trait.def] = new List<Trait>();
+                }
+                traitDict[trait.def].Add(trait);
+            }
+            return traitDict;
+        }
+
+        static PawnCreationManager()
+        {
+            // Initialize the good and bad trait dictionaries
+            goodTraitDict = InitializeTraitDictionary(goodTraits);
+            badTraitDict = InitializeTraitDictionary(badTraits);
+        }
+
+        private static List<Trait> SelectRandomTraits(Dictionary<TraitDef, List<Trait>> traitDictionary, int numTraitsToSelect)
+        {
+            List<Trait> selectedTraits = new List<Trait>();
+
+            // Create a new copy of the trait dictionary for each colonist
+            Dictionary<TraitDef, List<Trait>> traitDictionaryCopy = new Dictionary<TraitDef, List<Trait>>(traitDictionary);
+
+
+            // Randomly select traits until the desired number is reached or no more traits are available
+            while (selectedTraits.Count < numTraitsToSelect && traitDictionaryCopy.Count > 0)
+            {
+                TraitDef randomTraitDef = traitDictionaryCopy.Keys.RandomElement();
+                List<Trait> traitsForType = traitDictionaryCopy[randomTraitDef];
+                Trait selectedTrait = traitsForType.RandomElement();
+                selectedTraits.Add(selectedTrait);
+                traitDictionaryCopy.Remove(randomTraitDef);
+            }
+
+            return selectedTraits;
+        }
+
         public static List<Thing> generateDefaultColonists(int amount, string name = null)
         {
             var currentMap = Find.CurrentMap;
@@ -95,28 +140,8 @@ namespace RimConnection
                 var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
                 newPawn.SetFaction(Faction.OfPlayer);
 
-                // Create a dictionary to store available traits for each trait type
-                Dictionary<TraitDef, List<Trait>> availableTraits = new Dictionary<TraitDef, List<Trait>>();
-                foreach (Trait trait in badTraits)
-                {
-                    if (!availableTraits.ContainsKey(trait.def))
-                    {
-                        availableTraits[trait.def] = new List<Trait>();
-                    }
-                    availableTraits[trait.def].Add(trait);
-                }
-
-                List<Trait> selectedTraits = new List<Trait>();
-
-                // Randomly select 3 different trait types
-                while (selectedTraits.Count < 3 && availableTraits.Count > 0)
-                {
-                    TraitDef randomTraitDef = availableTraits.Keys.RandomElement();
-                    List<Trait> traitsForType = availableTraits[randomTraitDef];
-                    Trait selectedTrait = traitsForType.RandomElement();
-                    selectedTraits.Add(selectedTrait);
-                    availableTraits.Remove(randomTraitDef);
-                }
+                // Generate 3 bad traits for the colonist
+                List<Trait> selectedTraits = SelectRandomTraits(badTraitDict, 3);
 
                 newPawn.story.traits.allTraits.Clear();
                 // Add the selected traits to the pawn
@@ -153,28 +178,8 @@ namespace RimConnection
                 var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
                 newPawn.SetFaction(Faction.OfPlayer);
 
-                // Create a dictionary to store available traits for each trait type
-                Dictionary<TraitDef, List<Trait>> availableTraits = new Dictionary<TraitDef, List<Trait>>();
-                foreach (Trait trait in goodTraits)
-                {
-                    if (!availableTraits.ContainsKey(trait.def))
-                    {
-                        availableTraits[trait.def] = new List<Trait>();
-                    }
-                    availableTraits[trait.def].Add(trait);
-                }
-
-                List<Trait> selectedTraits = new List<Trait>();
-
-                // Randomly select 3 different trait types
-                while (selectedTraits.Count < 3 && availableTraits.Count > 0)
-                {
-                    TraitDef randomTraitDef = availableTraits.Keys.RandomElement();
-                    List<Trait> traitsForType = availableTraits[randomTraitDef];
-                    Trait selectedTrait = traitsForType.RandomElement();
-                    selectedTraits.Add(selectedTrait);
-                    availableTraits.Remove(randomTraitDef);
-                }
+                // Generate 3 good traits for the colonist
+                List<Trait> selectedTraits = SelectRandomTraits(goodTraitDict, 3);
 
                 newPawn.story.traits.allTraits.Clear();
                 // Add the selected traits to the pawn
@@ -221,28 +226,8 @@ namespace RimConnection
                     newPawn.Name = new NameTriple("Worst", "Myseenee", "Ever");
                 }
 
-                // Create a dictionary to store available traits for each trait type
-                Dictionary<TraitDef, List<Trait>> availableTraits = new Dictionary<TraitDef, List<Trait>>();
-                foreach (Trait trait in badTraits)
-                {
-                    if (!availableTraits.ContainsKey(trait.def))
-                    {
-                        availableTraits[trait.def] = new List<Trait>();
-                    }
-                    availableTraits[trait.def].Add(trait);
-                }
-
-                List<Trait> selectedTraits = new List<Trait>();
-
-                // Randomly select 5 different trait types
-                while (selectedTraits.Count < 5 && availableTraits.Count > 0)
-                {
-                    TraitDef randomTraitDef = availableTraits.Keys.RandomElement();
-                    List<Trait> traitsForType = availableTraits[randomTraitDef];
-                    Trait selectedTrait = traitsForType.RandomElement();
-                    selectedTraits.Add(selectedTrait);
-                    availableTraits.Remove(randomTraitDef);
-                }
+                // Generate 5 bad traits for the colonist
+                List<Trait> selectedTraits = SelectRandomTraits(badTraitDict, 5);
 
                 newPawn.story.traits.allTraits.Clear();
                 // Add the selected traits to the pawn

--- a/Source/RimConnection/Managers/PawnCreationManager.cs
+++ b/Source/RimConnection/Managers/PawnCreationManager.cs
@@ -50,6 +50,7 @@ namespace RimConnection
             new Trait(TraitDefOf.Kind),
             new Trait(DefDatabase<TraitDef>.GetNamed("Nimble")),
             new Trait(DefDatabase<TraitDef>.GetNamed("QuickSleeper")),
+            new Trait(DefDatabase<TraitDef>.GetNamed("NightOwl")),
         });
 
         public static List<Thing> generateDefaultColonists(int amount, string name = null)

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -32,13 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp">
-      <Version>106.11.4</Version>
+      <Version>106.15.0</Version>
     </PackageReference>
     <PackageReference Include="RimWorld.MultiplayerAPI">
       <Version>0.4.0</Version>
     </PackageReference>
     <PackageReference Include="Krafs.Rimworld.Ref">
-      <Version>1.4.3555</Version>
+      <Version>1.4.3704</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I added several additional traits that I felt were objectively good/bad to the pawn "good trait" and "bad trait" list used when good/bad colonists are purchased. "Night owl" is also added as a good trait for variety, as although it can result in a mood debuff if awake during the day, the constant mood bonus from being awake at night and the fact that they will use workbenches when other pawns are normally asleep is a net positive. All other new traits are objectively positive/negative only.

In addition, previously both trait lists only had degree "2" traits, so I added the degree "1" traits in both directions for more variety. I adjusted the code to use a traitType "dictionary" to pull traits from, preventing it from randomly choosing both the degree "1" and degree "2" trait on the same pawn. 