### PR TITLE
Fix: bought animals use NameSingle instead of NameTriple

### DIFF
--- a/Source/RimConnection/Actions/Resources/TameAnimalAction.cs
+++ b/Source/RimConnection/Actions/Resources/TameAnimalAction.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using RimWorld;
-using RimWorld.Planet;
 using Verse;
 
 namespace RimConnection

--- a/Source/RimConnection/Actions/Resources/TameAnimalAction.cs
+++ b/Source/RimConnection/Actions/Resources/TameAnimalAction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using RimWorld;
+using RimWorld.Planet;
 using Verse;
 
 namespace RimConnection
@@ -51,7 +52,7 @@ namespace RimConnection
                 Pawn newAnimal = PawnGenerator.GeneratePawn(itemDef.race.AnyPawnKind, Faction.OfPlayer);
                 if(boughtBy != "Poll")
                 {
-                    newAnimal.Name = new NameTriple("", boughtBy, "");
+                    newAnimal.Name = new NameSingle(boughtBy);
                 }
                 pawnList.Add(newAnimal);
             }


### PR DESCRIPTION
Previously, bought animals would be named with NameTriples, which would work but caused the naming window to display differently and prevented renaming them, as the first and last names were blank and would display an error that "The chosen name is invalid" when attempting to rename them. Setting the names to NameSingle allows them to be renamed, for example if the viewer that bought the animal requests a new name for them.