### PR TITLE
Missing description fix

### DIFF
--- a/Source/RimConnection/API/RimConnectAPI.cs
+++ b/Source/RimConnection/API/RimConnectAPI.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Verse;
 using RestSharp;
 using System;
@@ -86,7 +86,8 @@ namespace RimConnection
                     if (validCommandResponse.StatusCode != System.Net.HttpStatusCode.OK)
                     {
                         RimConnectSettings.initialiseSuccessful = false;
-                        Log.Error("Failed to provide valid commands to the server");
+                        string commandDetails = validCommandResponse.Content ?? "Payload chunk is null";
+                        Log.Error($"Failed to provide valid commands to server. Response Details: {commandDetails}");
                         return;
                     }
                 }

--- a/Source/RimConnection/API/RimConnectAPI.cs
+++ b/Source/RimConnection/API/RimConnectAPI.cs
@@ -76,9 +76,12 @@ namespace RimConnection
                 while(commandPayloadGenerator.isThereAnotherChunk())
                 {
                     ValidCommandListPostPayload payloadChunk = commandPayloadGenerator.getNextChunk();
-                    if (payloadChunk.description == null || !(payloadChunk.description is string))
+                    foreach (var command in payloadChunk.validCommands)
                     {
-                        payloadChunk.description = ""; 
+                        if (string.IsNullOrEmpty(command.description))
+                        {
+                            command.description = "";
+                        }
                     }
                     var validCommandRequest = new RestRequest("command/valid", Method.POST);
                     validCommandRequest.AddHeader("Content-Type", "application/json")

--- a/Source/RimConnection/API/RimConnectAPI.cs
+++ b/Source/RimConnection/API/RimConnectAPI.cs
@@ -81,6 +81,7 @@ namespace RimConnection
                         if (string.IsNullOrEmpty(command.description))
                         {
                             command.description = "description missing";
+                            Log.Warning($"Description missing for {command.name}");
                         }
                     }
                     var validCommandRequest = new RestRequest("command/valid", Method.POST);

--- a/Source/RimConnection/API/RimConnectAPI.cs
+++ b/Source/RimConnection/API/RimConnectAPI.cs
@@ -76,6 +76,10 @@ namespace RimConnection
                 while(commandPayloadGenerator.isThereAnotherChunk())
                 {
                     ValidCommandListPostPayload payloadChunk = commandPayloadGenerator.getNextChunk();
+                    if (payloadChunk.description == null || !(payloadChunk.description is string))
+                    {
+                        payloadChunk.description = ""; 
+                    }
                     var validCommandRequest = new RestRequest("command/valid", Method.POST);
                     validCommandRequest.AddHeader("Content-Type", "application/json")
                            .AddHeader("Authorization", $"Bearer {RimConnectSettings.token}")

--- a/Source/RimConnection/API/RimConnectAPI.cs
+++ b/Source/RimConnection/API/RimConnectAPI.cs
@@ -80,7 +80,7 @@ namespace RimConnection
                     {
                         if (string.IsNullOrEmpty(command.description))
                         {
-                            command.description = "";
+                            command.description = "description missing";
                         }
                     }
                     var validCommandRequest = new RestRequest("command/valid", Method.POST);


### PR DESCRIPTION
Allows Commands to be provided to the Server with VFE Deserters in the mod list by replacing empy/null descriptions.
Also adds additional debug output on validCommandResponse failure.