### PR TITLE
RimWorld 1.6 Compatibility

### DIFF
--- a/Source/RimConnection/About/About.xml
+++ b/Source/RimConnection/About/About.xml
@@ -7,6 +7,7 @@
   </url>
   <supportedVersions>
     <li>1.5</li>
+	<li>1.6</li>
   </supportedVersions>
   <packageId>betterscenes.rimconnect</packageId>
   <modDependencies>
@@ -27,7 +28,7 @@
   </loadAfter>
   <description>Twitch integration with RimConnect extension 
   
-Version 1.5.0
+Version 1.6.0
 
 === ABOUT ===
 

--- a/Source/RimConnection/About/Manifest.xml
+++ b/Source/RimConnection/About/Manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
   <identifier>RimConnect</identifier>
-  <version>1.4.0</version>
+  <version>1.6.0</version>
   <loadAfter>
     <li>Ludeon.RimWorld</li>
     <li>Ludeon.RimWorld.Royalty</li>

--- a/Source/RimConnection/Actions/Events/AnimalMetamorphosisAction.cs
+++ b/Source/RimConnection/Actions/Events/AnimalMetamorphosisAction.cs
@@ -42,7 +42,7 @@ namespace RimConnection
 
                 animal.Destroy();
 
-                Pawn replacementAnimal = PawnGenerator.GeneratePawn(newAnimal, animalFaction);
+                Pawn replacementAnimal = PawnGenerator.GeneratePawn(new PawnGenerationRequest(newAnimal, animalFaction));
                 replacementAnimal.relations = animalRelations;
 
                 if (animal.Faction == Faction.OfPlayer)

--- a/Source/RimConnection/Actions/Events/MasterworkBedsAction.cs
+++ b/Source/RimConnection/Actions/Events/MasterworkBedsAction.cs
@@ -22,14 +22,18 @@ namespace RimConnection
         {
             var currentMap = Find.CurrentMap;
 
-            var allBeds = currentMap.listerThings.ThingsInGroup(ThingRequestGroup.Bed).ToList();
-
-            allBeds.ForEach(bed =>
+            var allBeds = currentMap.listerThings.ThingsInGroup(ThingRequestGroup.Bed);
+            foreach (var thing in allBeds)
             {
-                bed.TryGetComp<CompQuality>().SetQuality(QualityCategory.Masterwork, ArtGenerationContext.Outsider);
-            });
+                var compQuality = thing.TryGetComp<CompQuality>();
+                if (compQuality != null)
+                {
+                    compQuality.SetQuality(QualityCategory.Masterwork, ArtGenerationContext.Outsider);
+                }
+            }
 
             AlertManager.NormalEventNotification("({0}) I feel like a toasty cinnamon bun, I never want to leave this bed. All your beds are masterwork!", boughtBy);
         }
+
     }
 }

--- a/Source/RimConnection/Actions/Events/PoorBedsAction.cs
+++ b/Source/RimConnection/Actions/Events/PoorBedsAction.cs
@@ -22,12 +22,15 @@ namespace RimConnection
         {
             var currentMap = Find.CurrentMap;
 
-            var allBeds = currentMap.listerThings.ThingsInGroup(ThingRequestGroup.Bed).ToList();
-
-            allBeds.ForEach(bed =>
+            var allBeds = currentMap.listerThings.ThingsInGroup(ThingRequestGroup.Bed);
+            foreach (var thing in allBeds)
             {
-                bed.TryGetComp<CompQuality>().SetQuality(QualityCategory.Poor, ArtGenerationContext.Outsider);
-            });
+                var compQuality = thing.TryGetComp<CompQuality>();
+                if (compQuality != null)
+                {
+                    compQuality.SetQuality(QualityCategory.Poor, ArtGenerationContext.Outsider);
+                }
+            }
 
             AlertManager.NormalEventNotification("({0}) Can't sleep, clown'll eat me. All your beds are now terrible.", boughtBy);
         }

--- a/Source/RimConnection/Actions/Events/RatSwarmEvent.cs
+++ b/Source/RimConnection/Actions/Events/RatSwarmEvent.cs
@@ -34,7 +34,7 @@ namespace RimConnection
             {
                 IntVec3 entryCell;
                 CellFinder.TryFindRandomCellNear(rootEntryCell, currentMap, 5, validator, out entryCell);
-                var newRat = Verse.PawnGenerator.GeneratePawn(rat);
+                var newRat = Verse.PawnGenerator.GeneratePawn(new PawnGenerationRequest(rat));
                 GenSpawn.Spawn(newRat, entryCell, currentMap);
                 newRat.mindState.mentalStateHandler.TryStartMentalState(MentalStateDefOf.Manhunter);
             }

--- a/Source/RimConnection/Actions/HeDiff/GenerateHeDiffActions.cs
+++ b/Source/RimConnection/Actions/HeDiff/GenerateHeDiffActions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-
 using RimWorld;
 using Verse;
 
@@ -8,18 +7,19 @@ namespace RimConnection
 {
     public static class GenerateHeDiffActions
     {
-
         public static List<IAction> GenerateHeDiffDefActions()
         {
-            IEnumerable<HediffGiver> heDiffGivers = PawnKindDefOf.Colonist.RaceProps.hediffGiverSets.SelectMany((HediffGiverSetDef set) => set.hediffGivers);
-            List<IAction> allConditionActions = heDiffGivers.Select(hediffGiver => CreateActionFromDef(hediffGiver)).ToList();
+            var sets = PawnKindDefOf.Colonist
+                       ?.RaceProps
+                       ?.hediffGiverSets;
+            if (sets == null)
+                return new List<IAction>();
 
-            return allConditionActions;
-        }
-
-        private static IAction CreateActionFromDef(HediffGiver hediffGiver)
-        {
-            return new HeDiffAction(hediffGiver.hediff);
+            return sets
+                .SelectMany(set => set?.hediffGivers ?? Enumerable.Empty<HediffGiver>())
+                .Where(g => g?.hediff != null)
+                .Select(g => (IAction)new HeDiffAction(g.hediff))
+                .ToList();
         }
     }
 }

--- a/Source/RimConnection/Actions/HeDiff/HeDiffAction.cs
+++ b/Source/RimConnection/Actions/HeDiff/HeDiffAction.cs
@@ -33,8 +33,16 @@ namespace RimConnection
         public override void Execute(int amount, string boughtBy)
         {
             //HediffDef heDiffDef = DefDatabase<HediffDef>.GetNamed(thingDef.defName);
-            HediffGiver heDiffGiver = PawnKindDefOf.Colonist.RaceProps.hediffGiverSets.SelectMany((HediffGiverSetDef set) => set.hediffGivers).Where((HediffGiver
-                hediffGiver) => hediffGiver.hediff.Equals(this.thingDef)).First();
+            var heDiffGiver = PawnKindDefOf.Colonist.RaceProps
+                .hediffGiverSets
+                .SelectMany(set => set.hediffGivers)
+                .FirstOrDefault(hg => hg.hediff == this.thingDef);
+            if (heDiffGiver == null)
+            {
+                Log.Error($"[HeDiffAction] No HediffGiver found for {thingDef.defName}");
+                return;
+            }
+
 
             String notificationMessage;
 

--- a/Source/RimConnection/Actions/Resources/ItemAction.cs
+++ b/Source/RimConnection/Actions/Resources/ItemAction.cs
@@ -49,7 +49,7 @@ namespace RimConnection
                 List<Thing> pawnList = new List<Thing>();
                 for (int i = 0; i < amount; i++)
                 {
-                    pawnList.Add(PawnGenerator.GeneratePawn(itemDef.race.AnyPawnKind, null));
+                    pawnList.Add(PawnGenerator.GeneratePawn(new PawnGenerationRequest(itemDef.race.AnyPawnKind, null)));
                 }
                 DropPodManager.createDropOfThings(pawnList, defLabel, dropMessage);
             }

--- a/Source/RimConnection/Actions/Resources/TameAnimalAction.cs
+++ b/Source/RimConnection/Actions/Resources/TameAnimalAction.cs
@@ -48,7 +48,7 @@ namespace RimConnection
             List<Thing> pawnList = new List<Thing>();
             for (int i = 0; i < amount; i++)
             {
-                Pawn newAnimal = PawnGenerator.GeneratePawn(itemDef.race.AnyPawnKind, Faction.OfPlayer);
+                Pawn newAnimal = PawnGenerator.GeneratePawn(new PawnGenerationRequest(itemDef.race.AnyPawnKind, Faction.OfPlayer));
                 if(boughtBy != "Poll")
                 {
                     newAnimal.Name = new NameSingle(boughtBy);

--- a/Source/RimConnection/IncidentWorkers/IncidentWorker_AlphaBeavers.cs
+++ b/Source/RimConnection/IncidentWorkers/IncidentWorker_AlphaBeavers.cs
@@ -37,7 +37,7 @@ public class IncidentWorker_Alphabeavers : IncidentWorker
         for (int i = 0; i < num; i++)
         {
             IntVec3 loc = CellFinder.RandomClosewalkCellNear(result, map, 10);
-            Pawn newThing = PawnGenerator.GeneratePawn(alphabeaver);
+            Pawn newThing = PawnGenerator.GeneratePawn(new PawnGenerationRequest(alphabeaver));
             Pawn pawn = (Pawn)GenSpawn.Spawn(newThing, loc, map);
             pawn.needs.food.CurLevelPercentage = 1f;
         }

--- a/Source/RimConnection/LoadFolders.xml
+++ b/Source/RimConnection/LoadFolders.xml
@@ -1,0 +1,10 @@
+<loadFolders>
+  <v1.5>
+    <li>/</li>
+    <li>1.5</li>
+  </v1.5>
+  <v1.6>
+    <li>/</li>
+    <li>1.6</li>
+  </v1.6>
+</loadFolders>

--- a/Source/RimConnection/Managers/PawnCreationManager.cs
+++ b/Source/RimConnection/Managers/PawnCreationManager.cs
@@ -108,7 +108,7 @@ namespace RimConnection
             int i = 0;
             while (i < amount)
             {
-                var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
+                var newPawn = PawnGenerator.GeneratePawn(new PawnGenerationRequest(PawnKindDefOf.Colonist));
                 newPawn.SetFaction(Faction.OfPlayer);
 
                 // mid range their skills
@@ -137,7 +137,7 @@ namespace RimConnection
             int i = 0;
             while (i < amount)
             {
-                var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
+                var newPawn = PawnGenerator.GeneratePawn(new PawnGenerationRequest(PawnKindDefOf.Colonist));
                 newPawn.SetFaction(Faction.OfPlayer);
 
                 // Generate 3 bad traits for the colonist
@@ -175,7 +175,7 @@ namespace RimConnection
             int i = 0;
             while (i < amount)
             {
-                var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
+                var newPawn = PawnGenerator.GeneratePawn(new PawnGenerationRequest(PawnKindDefOf.Colonist));
                 newPawn.SetFaction(Faction.OfPlayer);
 
                 // Generate 3 good traits for the colonist
@@ -214,7 +214,7 @@ namespace RimConnection
             int i = 0;
             while (i < amount)
             {
-                var newPawn = PawnGenerator.GeneratePawn(PawnKindDefOf.Colonist);
+                var newPawn = PawnGenerator.GeneratePawn(new PawnGenerationRequest(PawnKindDefOf.Colonist));
                 newPawn.SetFaction(Faction.OfPlayer);
 
                 if (newPawn.gender == Gender.Male)

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>$(RIMWORLD_BASE_PATH)\Mods\RimConnect\1.3\Assemblies</OutputPath>
+    <OutputPath>..\..\..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\RimWorld\Mods\RimConnect\1.6\Assemblies\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>$(RIMWORLD_BASE_PATH)\Mods\RimConnect\1.3\Assemblies</OutputPath>
+    <OutputPath>$(RIMWORLD_BASE_PATH)\Mods\RimConnect\1.6\Assemblies</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>$(RIMWORLD_BASE_PATH)\Mods\RimConnect\1.6\Assemblies\</OutputPath>
+    <OutputPath>$(RIMWORLD_BASE_PATH)\Mods\RimConnect\1.6\Assemblies</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -146,6 +146,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>..\..\About\PublishedFileId.txt</TargetPath>
     </ContentWithTargetPath>
+    <ContentWithTargetPath Include="LoadFolders.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>..\..\LoadFolders.xml</TargetPath>
+    </ContentWithTargetPath>
     <ContentWithTargetPath Include="Defs\**" CopyToOutputDirectory="PreserveNewest" TargetPath="..\..\Defs\%(RecursiveDir)%(Filename)%(Extension)" />
     <ContentWithTargetPath Include="Languages\**" CopyToOutputDirectory="PreserveNewest" TargetPath="..\..\Languages\English\Keyed\%(Filename)%(Extension)" />
   </ItemGroup>

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -38,7 +38,7 @@
       <Version>0.5.0</Version>
     </PackageReference>
     <PackageReference Include="Krafs.Rimworld.Ref">
-      <Version>1.5.4061</Version>
+      <Version>1.6.4503-beta</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/RimConnection/RimConnection.csproj
+++ b/Source/RimConnection/RimConnection.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\RimWorld\Mods\RimConnect\1.6\Assemblies\</OutputPath>
+    <OutputPath>$(RIMWORLD_BASE_PATH)\Mods\RimConnect\1.6\Assemblies\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
This PR brings RimConnect in line with the 1.6 API and fixes a handful of breaking changes:

 - Adds compatibility for RimWorld 1.6.
   - Updated About.xml and Manifest.xml metadata to reflect 1.6 compatibility
   - Migrated pawn generation calls to PawnGenerator.GeneratePawn(new PawnGenerationRequest(...))
   - Added null checks for CompQuality in MasterworkBedsAction and PoorBedsAction to prevent Null Reference Exceptions when operating on beds without quality comps.
   - Added null checks for HediffGivers in HeDiffAction
 - Retains compatibility for RimWorld 1.5
   - Added LoadFolders.xml to unnecessarily direct 1.5/1.6 game version to the proper assembles
   - Requires old 1.5 assemblies to be packaged in mod release, they are not built by the solution.
     - [This 1.6 release](https://github.com/Kuuchuu/RimConnect-mod/releases/tag/1.6) contains both the old 1.5 and new 1.6 assemblies.

Resolves https://github.com/Better-Scenes/RimConnect-mod/issues/56